### PR TITLE
refactor: remove duplicate default export

### DIFF
--- a/assets/javascripts/discourse/components/community-fortune.js
+++ b/assets/javascripts/discourse/components/community-fortune.js
@@ -1,7 +1,9 @@
 import Component from "@glimmer/component";
 import I18n from "I18n";
+import { hbs } from "ember-cli-htmlbars";
+import { setComponentTemplate } from "@ember/component";
 
-export default class CommunityFortune extends Component {
+class CommunityFortune extends Component {
   fortune = this.randomFortune();
 
   randomFortune() {
@@ -11,8 +13,9 @@ export default class CommunityFortune extends Component {
   }
 }
 
-<template>
-  <div class="community-fortune">
+export default setComponentTemplate(
+  hbs`<div class="community-fortune">
     {{i18n "community_fortune.fortune_label"}}: {{this.fortune}}
-  </div>
-</template>
+  </div>`,
+  CommunityFortune
+);


### PR DESCRIPTION
## Summary
- rewrite community fortune component to export template and class together using `setComponentTemplate`

## Testing
- `pnpm lint` *(fails: Unsupported environment (bad pnpm and/or Node.js version))*

------
https://chatgpt.com/codex/tasks/task_e_689301291a3c832ca60927b53aa66ab1