### PR TITLE
Fix fortune translation retrieval

### DIFF
--- a/assets/javascripts/discourse/components/community-fortune.js
+++ b/assets/javascripts/discourse/components/community-fortune.js
@@ -7,12 +7,14 @@ class CommunityFortune extends Component {
   fortune = this.randomFortune();
 
   randomFortune() {
-    const fortunes = I18n.t("community_fortune.fortunes");
-    console.log("Available fortunes:", fortunes); // 디버깅용
-    if (!Array.isArray(fortunes)) {
+    const fortunes =
+      I18n.translations?.[I18n.locale]?.js?.community_fortune?.fortunes || [];
+
+    if (!Array.isArray(fortunes) || fortunes.length === 0) {
       console.error("Fortunes is not an array:", fortunes);
       return "Translation error";
     }
+
     const index = Math.floor(Math.random() * fortunes.length);
     return fortunes[index];
   }


### PR DESCRIPTION
## Summary
- Retrieve fortunes directly from translation data to avoid "Translation error"

## Testing
- `pnpm install` *(fails: unsupported Node version)*
- `pnpm install --engine-strict=false` *(fails: 403 Forbidden from registry)*
- `bundle install` *(fails: 403 Forbidden from rubygems)*
- `bundle exec rspec spec/system/core_features_spec.rb` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68930ec8f90c832c8abcae925043c3e5