### PR TITLE
fix: resolve plugin image URLs

### DIFF
--- a/assets/javascripts/discourse/components/community-fortune.js
+++ b/assets/javascripts/discourse/components/community-fortune.js
@@ -28,10 +28,13 @@ class CommunityFortune extends Component {
 export default setComponentTemplate(
   hbs`
     <div class="fortune-cookie-container {{if this.opened "opened"}}">
-      <img src="/plugins/community-fortune/images/cookie-left.png" class="cookie cookie-left" alt="left cookie" />
-      <img src="/plugins/community-fortune/images/cookie-right.png" class="cookie cookie-right" alt="right cookie" />
+      <img src={{get-url "/plugins/community-fortune/images/cookie-left.png"}} class="cookie cookie-left" alt="left cookie" />
+      <img src={{get-url "/plugins/community-fortune/images/cookie-right.png"}} class="cookie cookie-right" alt="right cookie" />
 
-      <div class="paper-strip">
+      <div
+        class="paper-strip"
+        style={{concat "background-image: url(" (get-url "/plugins/community-fortune/images/paper.png") ");"}}
+      >
         {{#if this.opened}}
           <span class="fortune-text">{{this.fortune}}</span>
         {{/if}}

--- a/assets/stylesheets/common/community-fortune.scss
+++ b/assets/stylesheets/common/community-fortune.scss
@@ -42,7 +42,8 @@
     margin: 0 auto;
     overflow: hidden;
     white-space: nowrap;
-    background: url("/plugins/community-fortune/images/paper.png") no-repeat center;
+    background-repeat: no-repeat;
+    background-position: center;
     background-size: cover;
     height: 60px;
     width: 0;


### PR DESCRIPTION
## Summary
- use `get-url` helper for fortune cookie images
- ensure paper strip background loads via inline `get-url`

## Testing
- `pnpm exec eslint .` *(fails: Cannot find package '@discourse/lint-configs')*
- `bundle exec rubocop` *(fails: command not found: rubocop)*

------
https://chatgpt.com/codex/tasks/task_e_68935e012360832cae05ed4f39cdbf9f