### PR TITLE
Log user info when fortune button is clicked

### DIFF
--- a/app/controllers/community_fortune/examples_controller.rb
+++ b/app/controllers/community_fortune/examples_controller.rb
@@ -5,6 +5,15 @@ module ::CommunityFortune
     requires_plugin PLUGIN_NAME
 
     def index
+      user_info =
+        if current_user
+          current_user.attributes
+        else
+          { error: "no current_user" }
+        end
+
+      Rails.logger.info("CommunityFortune user info: #{user_info}")
+
       render json: { hello: "world" }
     end
   end

--- a/assets/javascripts/discourse/components/community-fortune.js
+++ b/assets/javascripts/discourse/components/community-fortune.js
@@ -4,13 +4,16 @@ import { action } from "@ember/object";
 import { hbs } from "ember-cli-htmlbars";
 import I18n from "I18n";
 import { setComponentTemplate } from "@ember/component";
+import { ajax } from "discourse/lib/ajax";
 
 class CommunityFortune extends Component {
   @tracked opened = false;
   @tracked fortune = "";
 
   @action
-  openCookie() {
+  async openCookie() {
+    await ajax("/community-fortune/examples.json");
+
     const fortunes =
       I18n.translations?.[I18n.locale]?.js?.community_fortune?.fortunes || [];
 


### PR DESCRIPTION
## Summary
- Log current user attributes on `/community-fortune/examples` endpoint
- Trigger logging request when the fortune cookie button is pressed

## Testing
- `pnpm lint` *(fails: Unsupported environment - requires Node >=22)*
- `bundle exec rake plugin:spec` *(fails: missing gems such as rubocop-discourse, activesupport, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6893dd262558832caee91c3186c80fb0